### PR TITLE
Use correct getrandom linux syscall on non-x86_64

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,6 +9,10 @@
 
 	"targetType": "library",
 
+	"dependencies-linux": {
+		"mir-linux-kernel": "~>1.0.0",
+	},
+
 	"configurations": [
 		{
 			"name": "library",

--- a/source/tanya/math/random.d
+++ b/source/tanya/math/random.d
@@ -96,7 +96,8 @@ abstract class EntropySource
 
 version (linux)
 {
-    extern (C) long syscall(long number, ...) nothrow @system @nogc;
+    import core.stdc.config : c_long;
+    extern (C) c_long syscall(c_long number, ...) nothrow @system @nogc;
 
     /**
      * Uses getrandom system call.
@@ -137,7 +138,8 @@ version (linux)
         do
         {
             // int getrandom(void *buf, size_t buflen, unsigned int flags);
-            auto length = syscall(318, output.ptr, output.length, 0);
+            import mir.linux._asm.unistd : NR_getrandom;
+            auto length = syscall(NR_getrandom, output.ptr, output.length, 0);
             Nullable!ubyte ret;
 
             if (length >= 0)
@@ -148,16 +150,13 @@ version (linux)
         }
     }
 
-    version (X86_64)
+    @nogc @system unittest
     {
-        private unittest
-        {
-            auto entropy = defaultAllocator.make!Entropy();
-            ubyte[blockSize] output;
-            output = entropy.random;
+        auto entropy = defaultAllocator.make!Entropy();
+        ubyte[blockSize] output;
+        output = entropy.random;
 
-            defaultAllocator.dispose(entropy);
-        }
+        defaultAllocator.dispose(entropy);
     }
 }
 


### PR DESCRIPTION
https://github.com/caraus-ecms/tanya/blob/bd2b88f16ece2b0631175bc1f91afae56ba5b3ed/source/tanya/math/random.d#L139-L140

The correct syscall number varies by architecture. We encountered this same issue when wanting to use getrandom for `mir.random.unpredictableSeed`.  Our solution was to create [mir-linux-kernel](https://github.com/libmir/mir-linux-kernel) with the correct syscall numbers for each architecture. The package does not contain any executable code -- it is in essence just a collection of header files. The above code is replaced with:

```d
import mir.linux._asm.unistd : NR_getrandom;
auto length = syscall(NR_getrandom, output.ptr, output.length, 0);
```

which will work painlessly on all platforms currently supported by DMD or LDC.