### PR TITLE
Use new __traits(isZeroInit) to check for a null initializer at compile time instead of runtime

### DIFF
--- a/source/tanya/algorithm/mutation.d
+++ b/source/tanya/algorithm/mutation.d
@@ -89,13 +89,20 @@ do
 
         static if (hasElaborateCopyConstructor!T || hasElaborateDestructor!T)
         {
-            if (typeid(T).initializer().ptr is null)
+            static if (__VERSION__ >= 2083) // __traits(isZeroInit) available.
             {
-                deinitialize!true(source);
+                deinitialize!(__traits(isZeroInit, T))(source);
             }
             else
             {
-                deinitialize!false(source);
+                if (typeid(T).initializer().ptr is null)
+                {
+                    deinitialize!true(source);
+                }
+                else
+                {
+                    deinitialize!false(source);
+                }
             }
         }
     }

--- a/source/tanya/conv.d
+++ b/source/tanya/conv.d
@@ -185,8 +185,16 @@ out(result; memory.ptr is result)
         }
         else
         {
-            static const T init = T.init;
-            trustedCopy(init);
+            static if (__VERSION__ >= 2083 // __traits(isZeroInit) available.
+                && __traits(isZeroInit, T))
+            {
+                (() @trusted => memory.ptr[0 .. T.sizeof])().fill!0;
+            }
+            else
+            {
+                static immutable T init = T.init;
+                trustedCopy(init);
+            }
         }
         result.__ctor(args);
     }


### PR DESCRIPTION
As done in https://github.com/dlang/phobos/pull/6698 and https://github.com/dlang/phobos/pull/6461.