### PR TITLE
Update to compile with DMD 2.105

### DIFF
--- a/meta/tanya/meta/trait.d
+++ b/meta/tanya/meta/trait.d
@@ -2335,7 +2335,7 @@ if (isCallable!F)
             }
             else
             {
-                enum getDefault(T[i .. i + 1] name)
+                auto getDefault(T[i .. i + 1] name)
                 {
                     return name[0];
                 }


### PR DESCRIPTION
https://dlang.org/changelog/2.105.0.html#dmd.enum-function

> enum on a function declaration had no effect other than being
> equivalent to the auto storage class when no return type was present.
> That syntax could be confused with enum manifest constants and is now
> an error... Instead, remove enum and use auto where necessary